### PR TITLE
feat: use X11 directly and drop xclip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libx11-dev libx11-6 dpkg xvfb
+          sudo apt-get install -y libx11-dev libx11-6 dpkg xvfb xclip
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "Current working directory before build: $(pwd)"
           echo "Content inside the directory ${ls}"
-          
+
       - name: Build latest .deb
         run: |
           chmod +x build_deb.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,20 +30,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Show current working directory (before build)
-        run: |
-          echo "Current working directory before build: $(pwd)"
-          echo "Content inside the directory ${ls}"
-
       - name: Build latest .deb
         run: |
           chmod +x build_deb.sh
           ./build_deb.sh
-
-      - name: Show current working directory (before install)
-        run: |
-          echo "Current working directory before install: $(pwd)"
-          echo "Content inside the directory ${ls}"
 
       - name: Install hcp .deb
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Show current working directory (before build)
         run: |
           echo "Current working directory before build: $(pwd)"
-
+          echo "Content inside the directory ${ls}"
+          
       - name: Build latest .deb
         run: |
           chmod +x build_deb.sh
@@ -42,10 +43,11 @@ jobs:
       - name: Show current working directory (before install)
         run: |
           echo "Current working directory before install: $(pwd)"
+          echo "Content inside the directory ${ls}"
 
       - name: Install hcp .deb
         run: |
-          sudo dpkg -i hcp-*.deb
+          sudo dpkg -i hcp_*.deb
           sudo apt-get install -f -y
 
       - name: Make test script executable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,23 +25,20 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y xclip wget dpkg xvfb
+          sudo apt-get install -y libx11-dev libx11-6 dpkg xvfb
 
-      - name: Download latest .deb from GitHub Releases
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build latest .deb
         run: |
-          LATEST_URL=$(curl -s https://api.github.com/repos/Agent-Hellboy/hcp/releases/latest | grep browser_download_url | grep .deb | cut -d '"' -f 4)
-          wget "$LATEST_URL" -O hcp_latest.deb
+          chmod +x build_deb.sh
+          ./build_deb.sh
 
       - name: Install hcp .deb
         run: |
-          sudo dpkg -i hcp_latest.deb
+          sudo dpkg -i hcp-*.deb
           sudo apt-get install -f -y
-
-      - name: Checkout test script
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            test_hcp.sh
 
       - name: Make test script executable
         run: chmod +x test_hcp.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Show current working directory (before build)
+        run: |
+          echo "Current working directory before build: $(pwd)"
+
       - name: Build latest .deb
         run: |
           chmod +x build_deb.sh
           ./build_deb.sh
+
+      - name: Show current working directory (before install)
+        run: |
+          echo "Current working directory before install: $(pwd)"
 
       - name: Install hcp .deb
         run: |

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SRCS=$(wildcard src/*.cpp)
 all: $(TARGET)
 
 $(TARGET): $(SRCS)
-	$(CXX) $(CXXFLAGS) -o $(TARGET) $(SRCS)
+	$(CXX) $(CXXFLAGS) -o $(TARGET) $(SRCS) -lX11
 
 clean:
 	rm -f $(TARGET) 

--- a/README.md
+++ b/README.md
@@ -49,14 +49,10 @@ hcp 2
 - Each entry is stored as: 4-byte length (uint32_t) followed by the clipboard content data.
 - The format allows efficient appending and reading of the entire history in reverse chronological order.
 - The service logs events to `~/.hcp/service.log`.
-- The maximum number of entries is set by `HCP_MAX_HISTORY` (default: 10).
 
 ## Troubleshooting
-- Make sure `xclip` is installed and working:
-  ```sh
-  xclip -selection clipboard -o
-  ```
 - If `~/.hcp/history.block` is not created, check `~/.hcp/service.log` for errors.
+- You can check service log using `sudo systemctl status hcp.service` 
 
 ## License
 See [LICENSE](LICENSE).

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -11,6 +11,9 @@ mkdir -p $PKGDIR/DEBIAN
 mkdir -p $PKGDIR/usr/bin
 mkdir -p $PKGDIR/etc/systemd/system
 
+# Ensure build dependency is installed
+sudo apt-get update && sudo apt-get install -y libx11-dev
+
 # Create control file
 cat > $PKGDIR/DEBIAN/control <<EOF
 Package: hcp
@@ -21,7 +24,7 @@ Architecture: amd64
 Maintainer: Prince Roshan <princekrroshan01@gmail.com>
 Description: HCP - Historical Clipboard Manager
  A historical clipboard manager with LRU history and systemd integration.
-Depends: xclip
+Depends: libx11-6
 EOF
 
 # Create postinst script directly

--- a/include/clipboard_mgmt.hpp
+++ b/include/clipboard_mgmt.hpp
@@ -1,6 +1,7 @@
 #ifndef CLIPBOARD_MGMT_HPP
 #define CLIPBOARD_MGMT_HPP
+#include <X11/Xlib.h>
 #include <string>
 
-std::string get_clipboard();
+std::string get_clipboard(Display *display);
 #endif // CLIPBOARD_MGMT_HPP

--- a/src/clipboard_mgmt.cpp
+++ b/src/clipboard_mgmt.cpp
@@ -183,7 +183,9 @@ std::string get_clipboard(Display *display) {
   unsigned long nitems, bytes_after;
   unsigned char *prop = nullptr;
 
-  int result = XGetWindowProperty(display, window, target, 0, (~0L), False,
+  // Limit clipboard data to reasonable size (e.g., 1MB)
+  const long max_clipboard_size = 1024 * 1024;
+  int result = XGetWindowProperty(display, window, target, 0, max_clipboard_size, False,
                                   AnyPropertyType, &actual_type, &actual_format,
                                   &nitems, &bytes_after, &prop);
 

--- a/src/clipboard_mgmt.cpp
+++ b/src/clipboard_mgmt.cpp
@@ -1,16 +1,114 @@
+/*
+To read clipboard, you must:
+
+    Ask: "Who owns it?"
+
+    Request data from that owner.
+
+    Wait for the reply.
+
+    Retrieve the data.
+
+flow
+               +-------------+
+               |   Firefox   |
+               | (Clipboard  |
+               |   Owner)    |
+               +------+------+
+                      |
+         1. Ctrl+C    |
+         -------------+
+                      |
+                      | 2. XSetSelectionOwner("CLIPBOARD")
+                      v
+               +------+------+
+               |   X11 Server |
+               +------+------+
+                      |
+                      |
+      3. No data stored — just remembers owner
+                      |
+                      |
+         4. Ctrl+V    |
+         <------------+
+                      |
+               +------+------+
+               |   Terminal   |
+               | (Requester)  |
+               +------+------+
+                      |
+                      |
+         5. Terminal asks: "Who owns CLIPBOARD?"
+                      |
+                      v
+               +------+------+
+               |   X11 Server |
+               +------+------+
+                      |
+         6. Server replies: "Firefox owns it"
+                      |
+                      v
+               +-------------+
+               |   Firefox   |
+               +-------------+
+                      |
+      7. Firefox receives SelectionRequest
+                      |
+      8. Firefox replies with clipboard data
+                      |
+                      v
+               +-------------+
+               |   Terminal  |
+               +-------------+
+         9. Terminal receives & pastes data
+
+
+*/
 #include "clipboard_mgmt.hpp"
-#include <cstdio>
+#include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#include <cstring>
 #include <string>
 
-std::string get_clipboard() {
-  std::string result;
-  FILE *pipe = popen("xclip -selection clipboard -o", "r");
-  if (!pipe)
+// NOTE: This code was generated with ChatGPT. I understand the general flow,
+// but haven't checked all X11 API details.
+std::string get_clipboard(Display *display) {
+  Atom clipboard = XInternAtom(display, "CLIPBOARD", False);
+  Atom utf8 = XInternAtom(display, "UTF8_STRING", False);
+  Atom target = utf8;
+
+  Window owner = XGetSelectionOwner(display, clipboard);
+  if (owner == None) {
     return "";
-  char buffer[128];
-  while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
-    result += buffer;
   }
-  pclose(pipe);
-  return result;
+
+  Window window = XCreateSimpleWindow(display, DefaultRootWindow(display), 0, 0,
+                                      1, 1, 0, 0, 0);
+
+  XConvertSelection(display, clipboard, target, target, window, CurrentTime);
+  XFlush(display);
+
+  XEvent event;
+  while (true) {
+    XNextEvent(display, &event);
+    if (event.type == SelectionNotify)
+      break;
+  }
+
+  Atom actual_type;
+  int actual_format;
+  unsigned long nitems, bytes_after;
+  unsigned char *prop = nullptr;
+
+  int result = XGetWindowProperty(display, window, target, 0, (~0L), False,
+                                  AnyPropertyType, &actual_type, &actual_format,
+                                  &nitems, &bytes_after, &prop);
+
+  std::string clipboard_content;
+  if (result == Success && prop) {
+    clipboard_content.assign(reinterpret_cast<char *>(prop), nitems);
+    XFree(prop);
+  }
+  XDestroyWindow(display, window);
+  return clipboard_content;
 }

--- a/src/clipboard_mgmt.cpp
+++ b/src/clipboard_mgmt.cpp
@@ -185,9 +185,9 @@ std::string get_clipboard(Display *display) {
 
   // Limit clipboard data to reasonable size (e.g., 1MB)
   const long max_clipboard_size = 1024 * 1024;
-  int result = XGetWindowProperty(display, window, target, 0, max_clipboard_size, False,
-                                  AnyPropertyType, &actual_type, &actual_format,
-                                  &nitems, &bytes_after, &prop);
+  int result = XGetWindowProperty(
+      display, window, target, 0, max_clipboard_size, False, AnyPropertyType,
+      &actual_type, &actual_format, &nitems, &bytes_after, &prop);
 
   std::string clipboard_content;
   if (result == Success && prop) {

--- a/src/clipboard_mgmt.cpp
+++ b/src/clipboard_mgmt.cpp
@@ -106,18 +106,25 @@ Clipboard Copy/Paste Flow in X11:
 
 Explanation of the select() Event Loop Flow Diagram:
 
-1. Start clipboard request: The program initiates a clipboard data request using XConvertSelection().
-2. Get X11 file descriptor: It retrieves the file descriptor for the X11 connection using ConnectionNumber(display).
+1. Start clipboard request: The program initiates a clipboard data request using
+XConvertSelection().
+2. Get X11 file descriptor: It retrieves the file descriptor for the X11
+connection using ConnectionNumber(display).
 3. Set timeout: A timeout (e.g., 1 second) is set using a timeval struct.
-4. Wait for data or timeout: The program uses select() to wait for data (an event) on the X11 file descriptor, or for the timeout to occur.
+4. Wait for data or timeout: The program uses select() to wait for data (an
+event) on the X11 file descriptor, or for the timeout to occur.
 5. Two possible outcomes:
    - Data available:
-     - If data is available, check with XPending() if there are any X events in the queue.
+     - If data is available, check with XPending() if there are any X events in
+the queue.
      - If yes, use XNextEvent() to get the next event.
-     - If the event is SelectionNotify, the clipboard data is ready and the process is done.
-     - If not, the loop continues until the timeout or a matching event is found.
+     - If the event is SelectionNotify, the clipboard data is ready and the
+process is done.
+     - If not, the loop continues until the timeout or a matching event is
+found.
    - Timeout:
-     - If no data arrives within the timeout, the program destroys the dummy window and returns an empty string, indicating failure.
+     - If no data arrives within the timeout, the program destroys the dummy
+window and returns an empty string, indicating failure.
 
 */
 #include "clipboard_mgmt.hpp"
@@ -138,7 +145,8 @@ std::string get_clipboard(Display *display) {
     return "";
   }
 
-  Window window = XCreateSimpleWindow(display, DefaultRootWindow(display), 0, 0, 1, 1, 0, 0, 0);
+  Window window = XCreateSimpleWindow(display, DefaultRootWindow(display), 0, 0,
+                                      1, 1, 0, 0, 0);
   if (window == None) {
     return "";
   }
@@ -154,9 +162,9 @@ std::string get_clipboard(Display *display) {
   while (true) {
     FD_ZERO(&readfds);
     FD_SET(x11_fd, &readfds);
-    timeout.tv_sec = 1;  // 1 second timeout
+    timeout.tv_sec = 1; // 1 second timeout
     timeout.tv_usec = 0;
-    
+
     if (select(x11_fd + 1, &readfds, NULL, NULL, &timeout) > 0) {
       if (XPending(display)) {
         XNextEvent(display, &event);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard reading now uses direct X11 protocol interaction instead of relying on external utilities, improving reliability and reducing external dependencies.

* **Bug Fixes**
  * Enhanced error handling when connecting to the X11 display, providing clearer feedback if the clipboard cannot be accessed.

* **Documentation**
  * Updated instructions to remove xclip dependency and added guidance for checking service logs via systemd.

* **Chores**
  * Updated build and packaging scripts to use X11 libraries instead of xclip.
  * Adjusted workflow automation to build the package from source, ensuring all dependencies are correctly installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->