### PR TITLE
Add basic gui tray app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,26 +22,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: List workspace files
+        run: ls -lR
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libx11-dev libx11-6 dpkg xvfb xclip
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
+          sudo apt-get install -y libx11-dev libx11-6 dpkg xvfb xclip libgtk-3-dev libappindicator3-dev
       - name: Build latest .deb
         run: |
           chmod +x build_deb.sh
           ./build_deb.sh
-
       - name: Install hcp .deb
         run: |
           sudo dpkg -i hcp_*.deb
           sudo apt-get install -f -y
-
       - name: Make test script executable
         run: chmod +x test_hcp.sh
-
       - name: Run hcp integration test
         run: xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' ./test_hcp.sh 

--- a/README.md
+++ b/README.md
@@ -130,3 +130,24 @@ hcp 2
 
 ## License
 See [LICENSE](LICENSE).
+
+## Manual Page
+
+After installing the package, you can view the manual page for usage and options:
+
+```
+man hcp
+```
+
+This provides detailed information about available commands and usage examples.
+
+## Starting the GUI Tray App
+
+After installing, you can enable and start the tray app (which sits in your system tray and provides clipboard history):
+
+```
+sudo systemctl enable hcp-tray@$(whoami).service
+sudo systemctl start hcp-tray@$(whoami).service
+```
+
+This will launch the tray app in the background for your user session.

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -24,7 +24,7 @@ Architecture: amd64
 Maintainer: Prince Roshan <princekrroshan01@gmail.com>
 Description: HCP - Historical Clipboard Manager
  A historical clipboard manager with LRU history and systemd integration.
-Depends: libx11-6
+Depends: libx11-6, libgtk-3-0, libappindicator3-1
 EOF
 
 # Create postinst script directly
@@ -60,12 +60,72 @@ echo ""
 echo "To check if your environment is set up correctly, run:"
 echo "  hcp --diagnostic"
 echo ""
+echo "To enable and start the GUI tray app (clipboard history in system tray), run:"
+echo "  sudo systemctl enable hcp-tray@${USERNAME}.service"
+echo "  sudo systemctl start hcp-tray@${USERNAME}.service"
 POSTINST
 chmod 755 $PKGDIR/DEBIAN/postinst
 
-# Build the binary
+# Build the main binary
 make
 cp hcp $PKGDIR/usr/bin/hcp
+
+# Build the GUI tray app
+cd gui && make && cd ..
+cp gui/hcp-tray $PKGDIR/usr/bin/hcp-tray
+
+# Add systemd service for tray app
+cat > $PKGDIR/etc/systemd/system/hcp-tray@.service <<EOF
+[Unit]
+Description=HCP Clipboard Tray App
+After=graphical-session.target
+
+[Service]
+Type=simple
+User=%i
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/home/%i/.Xauthority
+ExecStart=/usr/bin/hcp-tray
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+EOF
+
+# Create the man page BEFORE building the .deb
+mkdir -p $PKGDIR/usr/share/man/man1
+cat > $PKGDIR/usr/share/man/man1/hcp.1 <<'EOF'
+.TH hcp 1 "$(date +%Y-%m-%d)" "$VERSION" "hcp manual"
+.SH NAME
+hcp \- Historical Clipboard Manager for X11
+.SH SYNOPSIS
+.B hcp
+[service start | list | <index> | pop | --help | -h]
+.SH DESCRIPTION
+.B hcp
+is a lightweight clipboard manager for X11 systems. It captures clipboard entries, maintains a history, and allows you to list, print, or remove entries. Designed for reliability and minimalism, it works directly with the X11 clipboard and is suitable for use as a background service or on-demand.
+.SH COMMANDS
+.TP
+.B service start
+Start clipboard monitoring service in the background.
+.TP
+.B list
+List clipboard history.
+.TP
+.B <index>
+Print clipboard entry at <index>.
+.TP
+.B pop
+Remove most recent clipboard entry.
+.TP
+.B --help, -h
+Show this help message.
+.SH AUTHOR
+Written by the hcp project contributors.
+.SH SEE ALSO
+clipboard(1)
+EOF
+gzip -f $PKGDIR/usr/share/man/man1/hcp.1
 
 # Build the .deb package
 dpkg-deb --build $PKGDIR
@@ -77,4 +137,8 @@ echo "After install, enable and start the service with:"
 echo "  sudo systemctl daemon-reload"
 echo "  sudo systemctl enable hcp@${USERNAME}.service"
 echo "  sudo systemctl start hcp@${USERNAME}.service"
-echo "\nYou can override the version by running: VERSION=your_version ./build_deb.sh" 
+echo "To enable and start the GUI tray app (clipboard history in system tray), run:"
+echo "  sudo systemctl enable hcp-tray@${USERNAME}.service"
+echo "  sudo systemctl start hcp-tray@${USERNAME}.service"
+echo ""
+echo "You can override the version by running: VERSION=your_version ./build_deb.sh" 

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -12,7 +12,7 @@ mkdir -p $PKGDIR/usr/bin
 mkdir -p $PKGDIR/etc/systemd/system
 
 # Ensure build dependency is installed
-apt-get update && apt-get install -y libx11-dev
+apt-get update && apt-get install -y libx11-dev libgtk-3-dev libappindicator3-dev
 
 # Create control file
 cat > $PKGDIR/DEBIAN/control <<EOF

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -1,0 +1,14 @@
+CXX = g++
+CXXFLAGS = -std=c++11 `pkg-config --cflags gtk+-3.0 appindicator3-0.1` -I../include
+LDFLAGS = `pkg-config --libs gtk+-3.0 appindicator3-0.1` -lX11
+
+SRC = trey_app.cpp ../src/clipboard_mgmt.cpp ../src/db.cpp ../src/logging.cpp 
+TARGET = hcp-tray
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET) 

--- a/gui/trey_app.cpp
+++ b/gui/trey_app.cpp
@@ -1,0 +1,68 @@
+#include <gtk/gtk.h>
+#include <libappindicator3-0.1/libappindicator/app-indicator.h>
+#include "../include/db.hpp"
+#include "../include/clipboard_mgmt.hpp"
+#include <X11/Xlib.h>
+#include <vector>
+#include <string>
+
+static void on_copy_clicked(GtkButton *button, gpointer user_data) {
+    const char *text = (const char *)user_data;
+    Display *display = XOpenDisplay(nullptr);
+    if (display) {
+        set_clipboard(display, std::string(text));
+        XCloseDisplay(display);
+    }
+}
+
+static void show_history_window(GtkWidget *, gpointer) {
+    GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(window), "Clipboard History");
+    gtk_window_set_default_size(GTK_WINDOW(window), 400, 400);
+
+    GtkWidget *scrolled = gtk_scrolled_window_new(NULL, NULL);
+    gtk_container_add(GTK_CONTAINER(window), scrolled);
+
+    GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+    gtk_container_add(GTK_CONTAINER(scrolled), vbox);
+
+    std::vector<std::string> history = load_clipboard_blocks();
+    for (const auto &entry : history) {
+        GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+        GtkWidget *label = gtk_label_new(entry.substr(0, 60).c_str());
+        gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+        GtkWidget *button = gtk_button_new_with_label("Copy");
+        g_signal_connect(button, "clicked", G_CALLBACK(on_copy_clicked), (gpointer)entry.c_str());
+        gtk_box_pack_start(GTK_BOX(hbox), label, TRUE, TRUE, 0);
+        gtk_box_pack_start(GTK_BOX(hbox), button, FALSE, FALSE, 0);
+        gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
+    }
+    gtk_widget_show_all(window);
+}
+
+int main(int argc, char **argv) {
+    gtk_init(&argc, &argv);
+
+    AppIndicator *indicator = app_indicator_new(
+        "clipboard-manager",
+        "system-run-symbolic",
+        APP_INDICATOR_CATEGORY_APPLICATION_STATUS
+    );
+    app_indicator_set_status(indicator, APP_INDICATOR_STATUS_ACTIVE);
+
+    GtkWidget *menu = gtk_menu_new();
+    GtkWidget *item_show = gtk_menu_item_new_with_label("Show Clipboard History");
+    g_signal_connect(item_show, "activate", G_CALLBACK(show_history_window), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), item_show);
+
+    GtkWidget *item_quit = gtk_menu_item_new_with_label("Quit");
+    g_signal_connect(item_quit, "activate", G_CALLBACK(gtk_main_quit), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), item_quit);
+
+    gtk_widget_show_all(menu);
+    app_indicator_set_menu(indicator, GTK_MENU(menu));
+
+    gtk_main();
+    return 0;
+}
+

--- a/include/clipboard_mgmt.hpp
+++ b/include/clipboard_mgmt.hpp
@@ -4,4 +4,5 @@
 #include <string>
 
 std::string get_clipboard(Display *display);
+void set_clipboard(Display *display, const std::string &text);
 #endif // CLIPBOARD_MGMT_HPP


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GUI tray application for clipboard management, included in the Debian package and manageable via systemd service for user sessions.
  * Introduced a manual page for the command-line tool with detailed usage and options.
  * Added functionality to set clipboard content directly from the application.

* **Documentation**
  * Updated README with instructions for accessing the manual page and starting the tray app using systemd.

* **Chores**
  * Updated package dependencies to support the new GUI tray app.
  * Enhanced installation scripts to guide users on enabling and starting the tray service.
  * Improved CI workflow to include dependencies for building and testing the GUI tray app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->